### PR TITLE
chore: remove linuxkit and dasel dependencies from the playbook

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -7,11 +7,9 @@ bfg_version: "1.12.13"
 #my_distribution_release: {{ansible_distribution_release}}
 my_distribution_release: xenial
 go_swagger: "0.19.0"
-linuxkit_version: "0.7"
 reflex_version: "v0.3.1"
 lab_version: "0.25.1"
 sshcode: "0.10.0"
-dasel_version: "1.23.0"
 operator_sdk_version: "1.18.0"
 rga_version: "0.9.6"
 zgrab2_version: "11611670fe78825916037bb99e16958ce237ea1e"
@@ -45,20 +43,6 @@ gh_products:
     package: "go{{golang_version}}.linux-amd64.tar.gz"
     is: "tgz"
     bundle: True
-  -
-    name: "linuxkit"
-    version: "{{linuxkit_version}}"
-    url: "https://github.com/linuxkit/linuxkit/releases/download/v{{linuxkit_version}}"
-    package: "linuxkit-linux-amd64"
-    is: "bin"
-    absent: true
-  -
-    name: "dasel"
-    version: "{{dasel_version}}"
-    url: "https://github.com/TomWright/dasel/releases/download/v{{dasel_version}}"
-    package: "dasel_linux_amd64"
-    is: "bin"
-    absent: true
   -
     name: "swagger"
     version: "{{go_swagger}}"


### PR DESCRIPTION
The linuxkit and dasel dependencies have been removed from the playbook as they are no longer needed.